### PR TITLE
Replace abandoned lit-Protocol/artifact-exists-action with gh api call

### DIFF
--- a/checkout-junit-reports/README.md
+++ b/checkout-junit-reports/README.md
@@ -2,3 +2,13 @@
 
 Checks out the JUnit reports from a Git branch and stores the SHA values in a GitHub artifact.
 On a job re-run this SHA will be used to check out the same test results to ensure a consistent test distribution.
+
+## Required permissions
+
+This action queries the workflow run's artifacts via the GitHub REST API, so the job's `GITHUB_TOKEN` must have at least `actions: read`. Modern repositories grant this by default, but workflows that explicitly restrict permissions need to include it:
+
+```yaml
+permissions:
+  actions: read
+  contents: read
+```

--- a/checkout-junit-reports/action.yml
+++ b/checkout-junit-reports/action.yml
@@ -38,9 +38,18 @@ runs:
   steps:
     - name: Check if JUnit reports SHA artifact exists
       id: junit-reports-sha-check
-      uses: lit-Protocol/artifact-exists-action@ff41b0e92208918c585721cbf3e866dfddaf7879 # v0
-      with:
-        name: ${{ inputs.artifact-name }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        ARTIFACT_NAME: ${{ inputs.artifact-name }}
+      run: |
+        if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
+            --jq ".artifacts[] | select(.name == \"$ARTIFACT_NAME\") | .name" \
+            | grep -q .; then
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
 
     - name: Download JUnit reports SHA artifact
       if: ${{ steps.junit-reports-sha-check.outputs.exists == 'true' }}


### PR DESCRIPTION
## Why

`checkout-junit-reports/action.yml` currently uses [`lit-Protocol/artifact-exists-action@ff41b0e9`](https://github.com/lit-Protocol/artifact-exists-action) to check if a JUnit reports SHA artifact has been uploaded in the current run. That action is effectively abandoned:

- Last commit was Feb 2024.
- Single `v0` release; no newer version.
- Manifest still declares `using: "node20"`.

GitHub Actions has begun emitting this deprecation warning on every workflow that uses `checkout-junit-reports`:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `lit-Protocol/artifact-exists-action@ff41b0e...`. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.

See [GitHub's deprecation announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## What

The original action's logic is a one-liner: call `artifactClient.getArtifact(name)` and output `exists=true|false`. This PR replaces it with an inline `gh api` call against the equivalent REST endpoint (`/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts`). No external dependency, fewer pinned SHAs to maintain, and `gh` is preinstalled on all GitHub-hosted runners.

```yaml
- name: Check if JUnit reports SHA artifact exists
  id: junit-reports-sha-check
  shell: bash
  env:
    GH_TOKEN: ${{ github.token }}
    ARTIFACT_NAME: ${{ inputs.artifact-name }}
  run: |
    if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/artifacts" \
        --jq ".artifacts[] | select(.name == \"$ARTIFACT_NAME\") | .name" \
        | grep -q .; then
      echo "exists=true" >> "$GITHUB_OUTPUT"
    else
      echo "exists=false" >> "$GITHUB_OUTPUT"
    fi
```

## Permissions

The original action used the internal `ACTIONS_RUNTIME_TOKEN`, which does not require explicit job permissions. The REST endpoint used here needs `actions: read` on `GITHUB_TOKEN`. Modern repositories grant this by default; the README has a new "Required permissions" section so workflows running with restrictive defaults know to opt in.

## Validation

The existing integration test in `.github/workflows/integration-test.yml` covers both code paths:

- `checkout-junit-reports` job (lines 15-168): exercises the artifact-exists branch via repeated `./checkout-junit-reports` calls and asserts the SHA artifact is created/downloaded correctly.
- `checkout-junit-reports-with-nonexistent-branch` job (lines 170-232): exercises the artifact-does-not-exist branch and asserts no SHA artifact is downloaded.

This PR's CI run should validate both paths automatically.